### PR TITLE
Update install instructions

### DIFF
--- a/pages/test-suites/cypress/installation.mdx
+++ b/pages/test-suites/cypress/installation.mdx
@@ -46,7 +46,10 @@ module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       // 🙋‍♂️ Add this line to install the replay plugin
-      replayPlugin(on, config);
+      replayPlugin(on, config, {
+        upload: true,
+        apiKey: process.env.REPLAY_API_KEY,
+      });
       // Make sure that setupNodeEvents returns config
       return config;
     },
@@ -58,13 +61,16 @@ module.exports = defineConfig({
 ```jsx copy filename="cypress.config.ts"
 import defineConfig from 'cypress'
 // 🙋‍♂️ Add this line to add the replay plugin
-import { replayPlugin } from "@replayio/cypress";
+import { plugin as replayPlugin } from "@replayio/cypress";
 
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       // 🙋‍♂️ Add this line to install the replay plugin
-      replayPlugin(on, config);
+      replayPlugin(on, config, {
+        upload: true,
+        apiKey: process.env.REPLAY_API_KEY,
+      });
       // Make sure that setupNodeEvents returns config
       return config;
     },
@@ -107,7 +113,7 @@ Test Suites are currently in closed Beta. If you’d like to start recording you
 
 <Video src="/videos/api-keys.mp4" />
 
-**3. Save that API in your CI environment as `RECORD_REPLAY_API_KEY`**
+**3. Save that API in your CI environment as `REPLAY_API_KEY`**
 
 This step may vary depending on your CI provider. You can learn more about how to set up environment variables with different CI providers [on this docs page](/test-suites/cypress/continuous-integration).
 
@@ -133,13 +139,7 @@ jobs:
           build: npm run build
           start: npm start
         env:
-          REPLAY_API_KEY: ${{ secrets.RECORD_REPLAY_API_KEY }}
-      # Always run this step so failed tests are uploaded
-      - name: Upload replays
-        if: always()
-        uses: replayio/action-upload@v0.5.1
-        with:
-          api-key: ${{ secrets.RECORD_REPLAY_API_KEY }}
+          REPLAY_API_KEY: ${{ secrets.REPLAY_API_KEY }}
 ```
 </Tabs.Tab>
 <Tabs.Tab>
@@ -156,19 +156,9 @@ jobs:
           command: "npm ci"
       - run:
           name: "Run Cypress Tests"
-          command: 'npx cypress run --browser "Replay Firefox"'
+          command: 'npx cypress run --browser replay-chromium'
           environment:
-            RECORD_ALL_CONTENT: 1
-            RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.log
-      - run:
-          name: "Upload to Replay"
-          when: always
-          command: |
-            npm i -g @replayio/replay@latest
-            export RECORD_REPLAY_METADATA_SOURCE_COMMIT_TITLE="$(git log --format=%s -n 1)"
-            replay metadata --init --keys source --warn
-            replay ls
-            replay upload-all --api-key $RECORD_REPLAY_API_KEY
+            REPLAY_API_KEY: ${REPLAY_API_KEY}
 workflows:
   cypress-test-workflow:
     jobs:


### PR DESCRIPTION
Updates install instructions for Cypress to recommend settings `apiKey` and `upload` in the plugin config.